### PR TITLE
ADH-38 add --allow-script-in-comments to javadoc

### DIFF
--- a/bigtop-packages/src/common/solr/do-component-build
+++ b/bigtop-packages/src/common/solr/do-component-build
@@ -29,6 +29,8 @@ BUILD_OPTS="-Dversion=${FULL_VERSION} -Dhadoop.version=${HADOOP_VERSION} \
 sed -i -e '/ENTITY.*hadoop.version/s#"[^"]*"#"'${HADOOP_VERSION}'"#' ./solr/test-framework/ivy.xml ./solr/core/ivy.xml
 sed -i -e '/<dependency org="org.mortbay.jetty" name="jetty"/s#/ *>#>#' solr/core/ivy.xml
 sed -i -e '/<dependency org="org.mortbay.jetty" name="jetty"/a<artifact name="jetty" ext="jar"/></dependency>' solr/core/ivy.xml
+# http://www.oracle.com/technetwork/java/javase/8u121-relnotes-3315208.html bug
+sed -i '1960 a additionalparam="--allow-script-in-comments"' lucene/common-build.xml
 
 # FIXME: this needs to be fixed at the product level
 ant $BUILD_OPTS ivy-bootstrap

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -185,7 +185,7 @@ bigtop {
     'tez' {
       name    = 'tez'
       relNotes = 'Apache TEZ'
-      version { base = '0.6.2'; pkg = base; release = 1 }
+      version { base = '0.7.1'; pkg = base; release = 1 }
       tarball { destination = "apache-${name}-${version.base}-src.tar.gz"
                 source      = destination }
       url     { download_path = "/$name/${version.base}/"


### PR DESCRIPTION
There is an incompability in java 8u121
http://www.oracle.com/technetwork/java/javase/8u121-relnotes-3315208.html

And tez bump to 0.7.1