### PR TITLE
ADH-8 OOZIE-2396 Fix startup issue

### DIFF
--- a/bigtop-packages/src/common/oozie/OOZIE-2396.patch
+++ b/bigtop-packages/src/common/oozie/OOZIE-2396.patch
@@ -1,0 +1,59 @@
+diff --git pom.xml pom.xml
+index ee26366..34c37ee 100644
+--- pom.xml
++++ pom.xml
+@@ -140,6 +140,7 @@
+                 <enabled>false</enabled>
+             </snapshots>
+         </repository>
++        <!--
+         <repository>
+             <id>Codehaus repository</id>
+             <url>http://repository.codehaus.org/</url>
+@@ -147,6 +148,7 @@
+                 <enabled>false</enabled>
+             </snapshots>
+         </repository>
++        -->
+         <repository>
+             <id>apache.snapshots.repo</id>
+             <url>https://repository.apache.org/content/groups/snapshots</url>
+@@ -1329,7 +1331,7 @@
+             <dependency>
+                 <groupId>commons-io</groupId>
+                 <artifactId>commons-io</artifactId>
+-                <version>2.1</version>
++                <version>2.4</version>
+             </dependency>
+ 
+             <dependency>
+@@ -1356,6 +1358,12 @@
+                 <version>${curator.version}</version>
+             </dependency>
+ 
++            <dependency>
++                <groupId>org.apache.curator</groupId>
++                <artifactId>curator-client</artifactId>
++                <version>${curator.version}</version>
++            </dependency>
++
+             <!-- examples -->
+             <dependency>
+                 <groupId>commons-httpclient</groupId>
+diff --git webapp/pom.xml webapp/pom.xml
+index 30fc7ff..bca2638 100644
+--- webapp/pom.xml
++++ webapp/pom.xml
+@@ -264,6 +264,12 @@
+                     <groupId>org.apache.hadoop</groupId>
+                     <artifactId>hadoop-client</artifactId>
+                     <scope>compile</scope>
++                    <exclusions>
++                        <exclusion>
++                            <groupId>javax.servlet.jsp</groupId>
++                            <artifactId>jsp-api</artifactId>
++                        </exclusion>
++                    </exclusions>
+                 </dependency>
+                 <dependency>
+                     <groupId>org.apache.oozie</groupId>

--- a/bigtop-packages/src/common/oozie/install_oozie.sh
+++ b/bigtop-packages/src/common/oozie/install_oozie.sh
@@ -209,7 +209,7 @@ mkdir ${WEBAPP_DIR}
 (cd ${WEBAPP_DIR} ; jar xf ${BUILD_DIR}/oozie.war)
 # OOZIE_HOME/lib
 mv -f ${WEBAPP_DIR}/WEB-INF/lib/* ${SERVER_LIB_DIR}/lib/
-touch ${SERVER_LIB_DIR}/webapps/oozie.war
+cp ${BUILD_DIR}/oozie.war ${SERVER_LIB_DIR}/oozie.war
 
 install -m 0755 ${EXTRA_DIR}/tomcat-deployment.sh ${SERVER_LIB_DIR}/tomcat-deployment.sh
 

--- a/bigtop-packages/src/common/oozie/install_oozie.sh
+++ b/bigtop-packages/src/common/oozie/install_oozie.sh
@@ -210,6 +210,8 @@ mkdir ${WEBAPP_DIR}
 # OOZIE_HOME/lib
 mv -f ${WEBAPP_DIR}/WEB-INF/lib/* ${SERVER_LIB_DIR}/lib/
 cp ${BUILD_DIR}/oozie.war ${SERVER_LIB_DIR}/oozie.war
+zip -d ${SERVER_LIB_DIR}/oozie.war  WEB-INF/lib/jsp-api*jar
+zip -d ${SERVER_LIB_DIR}/oozie.war  WEB-INF/lib/servlet-api*jar
 
 install -m 0755 ${EXTRA_DIR}/tomcat-deployment.sh ${SERVER_LIB_DIR}/tomcat-deployment.sh
 

--- a/bigtop-packages/src/rpm/oozie/SPECS/oozie.spec
+++ b/bigtop-packages/src/rpm/oozie/SPECS/oozie.spec
@@ -68,6 +68,7 @@ Source9: tomcat-deployment.sh
 Source10: oozie-site.xml
 Source11: bigtop.bom
 Source12: OOZIE-2396.patch
+Source13: jsp_remove.patch
 #BIGTOP_PATCH_FILES
 Requires(pre): /usr/sbin/groupadd, /usr/sbin/useradd
 Requires(post): /sbin/chkconfig
@@ -141,7 +142,8 @@ Requires: bigtop-utils >= 0.7
 #BIGTOP_PATCH_COMMANDS
 
 %build
-	patch --ignore-whitespace < %{SOURCE12}
+patch --ignore-whitespace < %{SOURCE12}
+patch -p0 --ignore-whitespace < %{SOURCE13}
     mkdir -p distro/downloads
     env DO_MAVEN_DEPLOY="" FULL_VERSION=%{oozie_base_version} bash -x %{SOURCE1}
 
@@ -211,6 +213,7 @@ fi
 %{lib_oozie}/bin/ooziedb.sh
 %{lib_oozie}/bin/oozie-setup.sh
 %{lib_oozie}/webapps
+%{lib_oozie}/oozie.war
 %{lib_oozie}/libtools
 %{lib_oozie}/lib
 %{lib_oozie}/oozie-sharelib.tar.gz

--- a/bigtop-packages/src/rpm/oozie/SPECS/oozie.spec
+++ b/bigtop-packages/src/rpm/oozie/SPECS/oozie.spec
@@ -67,6 +67,7 @@ Source8: hive.xml
 Source9: tomcat-deployment.sh
 Source10: oozie-site.xml
 Source11: bigtop.bom
+Source12: OOZIE-2396.patch
 #BIGTOP_PATCH_FILES
 Requires(pre): /usr/sbin/groupadd, /usr/sbin/useradd
 Requires(post): /sbin/chkconfig
@@ -140,6 +141,7 @@ Requires: bigtop-utils >= 0.7
 #BIGTOP_PATCH_COMMANDS
 
 %build
+	patch --ignore-whitespace < %{SOURCE12}
     mkdir -p distro/downloads
     env DO_MAVEN_DEPLOY="" FULL_VERSION=%{oozie_base_version} bash -x %{SOURCE1}
 


### PR DESCRIPTION
the destination path for sharelib is: /user/oozie/share/lib/lib_20170626092357
Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/commons/io/Charsets
	at org.apache.hadoop.security.Credentials.<clinit>(Credentials.java:222)
	at org.apache.hadoop.mapred.JobConf.<init>(JobConf.java:334)
	at org.apache.oozie.service.HadoopAccessorService.createJobConf(HadoopAccessorService.java:349)
	at org.apache.oozie.tools.OozieSharelibCLI.run(OozieSharelibCLI.java:171)
	at org.apache.oozie.tools.OozieSharelibCLI.main(OozieSharelibCLI.java:67)
Caused by: java.lang.ClassNotFoundException: org.apache.commons.io.Charsets