### PR TITLE
Disable orca in configure for gpdb

### DIFF
--- a/bigtop-packages/src/common/gpdb/do-component-configure
+++ b/bigtop-packages/src/common/gpdb/do-component-configure
@@ -16,4 +16,4 @@
 
 set -ex
 
-./configure --prefix=$1
+./configure --prefix=$1 --disable-orca


### PR DESCRIPTION
It looks like orca is enabled now by default. That is the cause
of following errro in beta5:

checking for gpos/_api.h... no
configure: error: GPOS header files are required for Pivotal Query Optimizer (orca)
error: Bad exit status from /var/tmp/rpm-tmp.dKMHSy (%build)
    Bad exit status from /var/tmp/rpm-tmp.dKMHSy (%build)