### PR TITLE
Bump hbase to 1.3.1

### DIFF
--- a/bigtop-packages/src/common/hbase/patch1-0001-Partial-backport-HBASE-16712-to-1.3.1.diff
+++ b/bigtop-packages/src/common/hbase/patch1-0001-Partial-backport-HBASE-16712-to-1.3.1.diff
@@ -1,0 +1,60 @@
+From 7e3b1d7f830b6e6abd5c4ee6a775f4063b648b60 Mon Sep 17 00:00:00 2001
+From: Anton Chevychalov <pub@mnu.pp.ru>
+Date: Fri, 8 Sep 2017 19:09:23 +0300
+Subject: [PATCH 1/2] Partial backport HBASE-16712 to 1.3.1
+
+That partial backport should fix net:jcip package licence trouble
+when we are building hbase with Hadoop 2.8.x
+
+https://issues.apache.org/jira/browse/HBASE-17893?focusedCommentId=15963617
+https://issues.apache.org/jira/browse/HBASE-16712
+---
+ .../src/main/resources/META-INF/LICENSE.vm             |  4 +++-
+ .../src/main/resources/supplemental-models.xml         | 18 ++++++++++++++++++
+ 2 files changed, 21 insertions(+), 1 deletion(-)
+
+diff --git a/hbase-resource-bundle/src/main/resources/META-INF/LICENSE.vm b/hbase-resource-bundle/src/main/resources/META-INF/LICENSE.vm
+index f403c89..0a4a23e 100644
+--- a/hbase-resource-bundle/src/main/resources/META-INF/LICENSE.vm
++++ b/hbase-resource-bundle/src/main/resources/META-INF/LICENSE.vm
+@@ -1561,7 +1561,9 @@ You can redistribute it and/or modify it under either the terms of the GPL
+ ## Whitelist of licenses that it's safe to not aggregate as above.
+ ## Note that this doesn't include ALv2 or the aforementioned aggregate
+ ## license mentions.
+-#set($non_aggregate_fine = [ 'Public Domain', 'New BSD license', 'BSD license', 'Mozilla Public License Version 2.0' ])
++##
++## See this FAQ link for justifications: https://www.apache.org/legal/resolved.html
++#set($non_aggregate_fine = [ 'Public Domain', 'New BSD license', 'BSD license', 'Mozilla Public License Version 2.0', 'Creative Commons Attribution License, Version 2.5', 'MPL 1.1'])
+ ## include LICENSE sections for anything not under ASL2.0
+ #foreach( ${dep} in ${projects} )
+ #if(${debug-print-included-work-info.equalsIgnoreCase("true")})
+diff --git a/hbase-resource-bundle/src/main/resources/supplemental-models.xml b/hbase-resource-bundle/src/main/resources/supplemental-models.xml
+index d6237d0..d5495cb 100644
+--- a/hbase-resource-bundle/src/main/resources/supplemental-models.xml
++++ b/hbase-resource-bundle/src/main/resources/supplemental-models.xml
+@@ -2047,4 +2047,22 @@ Copyright (c) 2007-2011 The JRuby project
+       </licenses>
+     </project>
+   </supplement>
++  <supplement>
++    <project>
++      <groupId>net.jcip</groupId>
++      <artifactId>jcip-annotations</artifactId>
++      <version>1.0</version>
++      <organization>
++        <name>Brian Goetz and Tim Peierls</name>
++        <url>http://www.jcip.net</url>
++      </organization>
++      <licenses>
++        <license>
++          <name>Creative Commons Attribution License, Version 2.5</name>
++          <url>http://creativecommons.org/licenses/by/2.5</url>
++          <distribution>repo</distribution>
++        </license>
++      </licenses>
++    </project>
++  </supplement>
+ </supplementalDataModels>
+-- 
+2.7.4
+

--- a/bigtop-packages/src/common/hbase/patch2-0002-Backport-HBASE-17893-to-1.3.diff
+++ b/bigtop-packages/src/common/hbase/patch2-0002-Backport-HBASE-17893-to-1.3.diff
@@ -1,0 +1,278 @@
+From 1a58e47067d64866917b8834eabc37e4c2887ebb Mon Sep 17 00:00:00 2001
+From: Anton Chevychalov <pub@mnu.pp.ru>
+Date: Fri, 8 Sep 2017 19:20:48 +0300
+Subject: [PATCH 2/2] Backport HBASE-17893 to 1.3
+
+---
+ .../src/main/resources/supplemental-models.xml     | 222 +++++++++++++++++++++
+ 1 file changed, 222 insertions(+)
+
+diff --git a/hbase-resource-bundle/src/main/resources/supplemental-models.xml b/hbase-resource-bundle/src/main/resources/supplemental-models.xml
+index d5495cb..e8e6bbb 100644
+--- a/hbase-resource-bundle/src/main/resources/supplemental-models.xml
++++ b/hbase-resource-bundle/src/main/resources/supplemental-models.xml
+@@ -644,6 +644,21 @@ under the License.
+     </project>
+   </supplement>
+   <supplement>
++    <project> <!-- hadoop.profile=3.0 from hadoop-3.0.0-alpha1 -->
++      <groupId>org.apache.commons</groupId>
++      <artifactId>commons-csv</artifactId>
++      <version>1.0</version>
++      <licenses>
++        <license>
++          <name>Apache License, Version 2.0</name>
++          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
++          <distribution>repo</distribution>
++        </license>
++      </licenses>
++    </project>
++  </supplement>
++
++  <supplement>
+     <project>
+       <groupId>org.apache.commons</groupId>
+       <artifactId>commons-math</artifactId>
+@@ -714,6 +729,21 @@ under the License.
+     </project>
+   </supplement>
+   <supplement>
++    <project>   <!-- hadoop.profile=3.0 from hadoop-3.0.0-alpha1 -->
++      <groupId>org.apache.curator</groupId>
++      <artifactId>curator-test</artifactId>
++      <version>2.7.1</version>
++
++      <licenses>
++        <license>
++          <name>Apache License, Version 2.0</name>
++          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
++          <distribution>repo</distribution>
++        </license>
++      </licenses>
++    </project>
++  </supplement>
++  <supplement>
+     <project>
+       <groupId>org.apache.directory.api</groupId>
+       <artifactId>api-asn1-api</artifactId>
+@@ -783,6 +813,21 @@ under the License.
+       </licenses>
+     </project>
+   </supplement>
++  <supplement>
++    <project>   <!-- hadoop.profile=3.0 from hadoop-3.0.0-alpha1 -->
++      <groupId>org.apache.htrace</groupId>
++      <artifactId>htrace-core4</artifactId>
++      <version>4.0.1-incubating</version>
++      <licenses>
++        <license>
++          <name>Apache License, Version 2.0</name>
++          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
++          <distribution>repo</distribution>
++        </license>
++      </licenses>
++    </project>
++  </supplement>
++
+   <!-- Used by Hadoop 2.6 -->
+   <supplement>
+     <project>
+@@ -980,6 +1025,7 @@ under the License.
+       </licenses>
+     </project>
+   </supplement>
++
+ <!-- Ambiguous license names in server and not in client -->
+   <supplement>
+     <project>
+@@ -1082,6 +1128,143 @@ Copyright 2006 Envoi Solutions LLC
+       </licenses>
+     </project>
+   </supplement>
++  <supplement>
++    <project>   <!-- hadoop.profile=3.0 from hadoop-3.0.0-alpha1 -->
++      <groupId>com.codahale.metrics</groupId>
++      <artifactId>metrics-core</artifactId>
++      <version>3.0.1</version>
++      <licenses>
++        <license>
++          <name>Apache License, Version 2.0</name>
++          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
++          <distribution>repo</distribution>
++        </license>
++      </licenses>
++    </project>
++  </supplement>
++  <supplement>
++    <project>   <!-- hadoop.profile=3.0 from hadoop-3.0.0-alpha1 -->
++      <groupId>com.nimbusds</groupId>
++      <artifactId>nimbus-jose-jwt</artifactId>
++      <version>3.9</version>
++      <licenses>
++        <license>
++          <name>Apache License, Version 2.0</name>
++          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
++          <distribution>repo</distribution>
++        </license>
++      </licenses>
++    </project>
++  </supplement>
++  <supplement>
++    <project>  <!-- hadoop.profile=3.0 from hadoop-3.0.0-alpha1 -->
++      <groupId>com.squareup.okhttp</groupId>
++      <artifactId>okhttp</artifactId>
++      <version>2.4.0</version>
++      <licenses>
++        <license>
++          <name>Apache License, Version 2.0</name>
++          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
++          <distribution>repo</distribution>
++        </license>
++      </licenses>
++    </project>
++  </supplement>
++  <supplement>
++    <project>  <!-- hadoop.profile=3.0 from hadoop-3.0.0-alpha1 -->
++      <groupId>com.squareup.okio</groupId>
++      <artifactId>okio</artifactId>
++      <version>1.4.0</version>
++      <licenses>
++        <license>
++          <name>Apache License, Version 2.0</name>
++          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
++          <distribution>repo</distribution>
++        </license>
++      </licenses>
++    </project>
++  </supplement>
++  <supplement>
++    <project>   <!-- hadoop.profile=3.0 from hadoop-3.0.0-alpha1 -->
++      <groupId>com.twitter</groupId>
++      <artifactId>hpack</artifactId>
++      <version>0.11.0</version>
++      <licenses>
++        <license>
++          <name>Apache License, Version 2.0</name>
++          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
++          <distribution>repo</distribution>
++        </license>
++      </licenses>
++    </project>
++  </supplement>
++  <supplement>
++    <project>   <!-- hadoop.profile=3.0 from hadoop-3.0.0-alpha1 -->
++      <groupId>net.minidev</groupId>
++      <artifactId>json-smart</artifactId>
++      <version>1.1.1</version>
++      <licenses>
++        <license>
++          <name>Apache License, Version 2.0</name>
++          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
++          <distribution>repo</distribution>
++        </license>
++      </licenses>
++    </project>
++  </supplement> 
++
++  <supplement>
++    <project>   <!-- hadoop.profile=3.0 from hadoop-3.0.0-alpha1 -->
++      <groupId>de.ruedigermoeller</groupId>
++      <artifactId>fst</artifactId>
++      <version>2.24</version>
++      <!-- versions 2.17+ are ASFv2 though pom says LGPL 2.1 until 2.45+ -->
++      <!-- https://github.com/RuedigerMoeller/fast-serialization/blob/master/LICENSE.md -->
++      <!-- https://github.com/RuedigerMoeller/fast-serialization/commit/526dd4#diff-600376-->
++
++      <licenses>
++        <license>
++          <name>Apache License, Version 2.0</name>
++          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
++          <distribution>repo</distribution>
++        </license>
++      </licenses>
++    </project>
++  </supplement>
++
++  <supplement>
++    <project>   <!-- hadoop.profile=3.0 from hadoop-3.0.0-alpha1 -->
++      <groupId>org.objenesis</groupId>
++      <artifactId>objenesis</artifactId>
++      <version>2.1</version>
++      <licenses>
++        <license>
++          <name>Apache License, Version 2.0</name>
++          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
++          <distribution>repo</distribution>
++        </license>
++      </licenses>
++    </project>
++  </supplement>
++
++  <!-- xercesImpl is necessary when using -Dhadoop.profile=3.0 due to a bug in maven. (last tested with mvn 3.3.9)
++       See HBASE-16712 for more details.-->
++  <supplement>
++    <project>
++      <groupId>xerces</groupId>
++      <artifactId>xercesImpl</artifactId>
++      <version>2.9.1</version>
++      <licenses>
++        <license>
++          <name>Apache License, Version 2.0</name>
++          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
++          <distribution>repo</distribution>
++        </license>
++      </licenses>
++    </project>
++  </supplement>
++
++
+ <!-- Permissive licenses that need text in LICENSE -->
+   <supplement>
+     <project>
+@@ -2065,4 +2248,43 @@ Copyright (c) 2007-2011 The JRuby project
+       </licenses>
+     </project>
+   </supplement>
++
++  <supplement>
++    <project>
++      <groupId>net.jcip</groupId>
++      <artifactId>jcip-annotations</artifactId>
++      <version>1.0</version>
++      <organization>
++        <name>Brian Goetz and Tim Peierls</name>
++        <url>http://www.jcip.net</url>
++      </organization>
++      <licenses>
++        <license>
++          <name>Creative Commons Attribution License, Version 2.5</name>
++          <url>http://creativecommons.org/licenses/by/2.5</url>
++          <distribution>repo</distribution>
++        </license>
++      </licenses>
++    </project>
++  </supplement>
++  <supplement>
++    <project>
++      <groupId>com.google.re2j</groupId>
++      <artifactId>re2j</artifactId>
++      <version>1.0</version>
++
++      <organization>
++        <name>The Go Authors</name>
++        <url>https://github.com/google/re2j</url>
++      </organization>
++      <licenses>
++        <license>
++          <name>BSD license</name> <!-- the Go license is BDS 3 clause verbatim -->
++          <url>https://github.com/google/re2j/blob/master/LICENSE</url>
++          <distribution>repo</distribution>
++        </license>
++      </licenses>
++    </project>
++  </supplement>
++
+ </supplementalDataModels>
+-- 
+2.7.4
+

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -165,7 +165,7 @@ bigtop {
     'hbase' {
       name    = 'hbase'
       relNotes = 'Apache HBase'
-      version { base = '1.1.9'; pkg = base; release = 1 }
+      version { base = '1.3.1'; pkg = base; release = 1 }
       tarball { destination = "${name}-${version.base}.tar.gz"
                 source      = "${name}-${version.base}-src.tar.gz" }
       url     { download_path = "/$name/${version.base}/"


### PR DESCRIPTION
There are a number of issues with licenses check when hbase
building with Hadoop 2.8.x

That patch bump hbase to latest release and add couple patches.