### PR TITLE
ADH-8 Remove useless jars from war

### DIFF
--- a/bigtop-packages/src/common/oozie/install_oozie.sh
+++ b/bigtop-packages/src/common/oozie/install_oozie.sh
@@ -210,6 +210,8 @@ mkdir ${WEBAPP_DIR}
 # OOZIE_HOME/lib
 mv -f ${WEBAPP_DIR}/WEB-INF/lib/* ${SERVER_LIB_DIR}/lib/
 cp ${BUILD_DIR}/oozie.war ${SERVER_LIB_DIR}/oozie.war
+zip -d ${SERVER_LIB_DIR}/oozie.war  WEB-INF/lib/jsp-api*jar
+zip -d ${SERVER_LIB_DIR}/oozie.war  WEB-INF/lib/servlet-api*jar
 
 install -m 0755 ${EXTRA_DIR}/tomcat-deployment.sh ${SERVER_LIB_DIR}/tomcat-deployment.sh
 

--- a/bigtop-packages/src/rpm/oozie/SPECS/oozie.spec
+++ b/bigtop-packages/src/rpm/oozie/SPECS/oozie.spec
@@ -68,6 +68,7 @@ Source9: tomcat-deployment.sh
 Source10: oozie-site.xml
 Source11: bigtop.bom
 Source12: OOZIE-2396.patch
+Source13: jsp_remove.patch
 #BIGTOP_PATCH_FILES
 Requires(pre): /usr/sbin/groupadd, /usr/sbin/useradd
 Requires(post): /sbin/chkconfig
@@ -141,7 +142,8 @@ Requires: bigtop-utils >= 0.7
 #BIGTOP_PATCH_COMMANDS
 
 %build
-	patch --ignore-whitespace < %{SOURCE12}
+patch --ignore-whitespace < %{SOURCE12}
+patch -p0 --ignore-whitespace < %{SOURCE13}
     mkdir -p distro/downloads
     env DO_MAVEN_DEPLOY="" FULL_VERSION=%{oozie_base_version} bash -x %{SOURCE1}
 
@@ -211,6 +213,7 @@ fi
 %{lib_oozie}/bin/ooziedb.sh
 %{lib_oozie}/bin/oozie-setup.sh
 %{lib_oozie}/webapps
+%{lib_oozie}/oozie.war
 %{lib_oozie}/libtools
 %{lib_oozie}/lib
 %{lib_oozie}/oozie-sharelib.tar.gz


### PR DESCRIPTION
org.apache.jasper.JasperException: Unable to compile class for JSP:

An error occurred at line: 25 in the generated java file
The method getJspApplicationContext(ServletContext) is undefined for the type JspFactory

Stacktrace:
    org.apache.jasper.compiler.DefaultErrorHandler.javacError(DefaultErrorHandler.java:92)
    org.apache.jasper.compiler.ErrorDispatcher.javacError(ErrorDispatcher.java:330)
    org.apache.jasper.compiler.JDTCompiler.generateClass(JDTCompiler.java:451)
    org.apache.jasper.compiler.Compiler.compile(Compiler.java:356)
    org.apache.jasper.compiler.Compiler.compile(Compiler.java:334)
    org.apache.jasper.compiler.Compiler.compile(Compiler.java:321)
    org.apache.jasper.JspCompilationContext.compile(JspCompilationContext.java:592)
    org.apache.jasper.servlet.JspServletWrapper.service(JspServletWrapper.java:328)
    org.apache.jasper.servlet.JspServlet.serviceJspFile(JspServlet.java:313)
    org.apache.jasper.servlet.JspServlet.service(JspServlet.java:260)
    javax.servlet.http.HttpServlet.service(HttpServlet.java:723)
    org.apache.oozie.servlet.AuthFilter$2.doFilter(AuthFilter.java:126)
    org.apache.hadoop.security.authentication.server.AuthenticationFilter.doFilter(AuthenticationFilter.java:585)
    org.apache.hadoop.security.authentication.server.AuthenticationFilter.doFilter(AuthenticationFilter.java:548)
    org.apache.oozie.servlet.AuthFilter.doFilter(AuthFilter.java:131)
    org.apache.oozie.servlet.HostnameFilter.doFilter(HostnameFilter.java:84)