### PR TITLE
ADH-333 Disable jar repack for oozie.

### DIFF
--- a/bigtop-packages/src/rpm/oozie/SPECS/oozie.spec
+++ b/bigtop-packages/src/rpm/oozie/SPECS/oozie.spec
@@ -21,6 +21,10 @@
 %define data_oozie /var/lib/oozie
 %define lib_hadoop /usr/lib/hadoop
 
+# disable repacking jars
+%define __os_install_post %{nil}
+%define __jar_repack ${nil}
+
 %if  %{!?suse_version:1}0
   %define doc_oozie %{_docdir}/oozie-%{oozie_version}
   %define initd_dir %{_sysconfdir}/rc.d/init.d


### PR DESCRIPTION
There is trouble with repacking on SLES:

resource_management.core.exceptions.ExecutionFailed:
Execution of '/usr/bin/zypper --quiet install --auto-agree-with-licenses --no-confirm oozie' returned 4.
Problem: nothing provides osgi(com.jcraft.jsch) needed by oozie-4.3.0-377.noarch