### PR TITLE
ADH-334 Change Hue deps on SLES

### DIFF
--- a/bigtop-packages/src/rpm/hue/SPECS/hue.spec
+++ b/bigtop-packages/src/rpm/hue/SPECS/hue.spec
@@ -190,11 +190,11 @@ BuildRequires: asciidoc
 BuildRequires: gmp-devel
 BuildRequires: libffi-devel
 Group: Applications/Engineering
-Requires: cyrus-sasl-gssapi, libxml2, libxslt, zlib, sqlite, libyaml, python, libffi
+Requires: cyrus-sasl-gssapi, libxml2, libxslt, zlib, sqlite, libyaml, python
 %if 0%{?suse_version}
-Requires: libgmp10
+Requires: libgmp10, libffi4
 %else
-Requires: gmp
+Requires: gmp, libffi
 %endif
 # The only reason we need the following is because we also have AutoProv: no
 Provides: config(%{name}-common) = %{version}


### PR DESCRIPTION
There is no package libffi on sles. There is libffi4 on it.