### PR TITLE
ADH-392 Patch atlas to allow build on linux/ppc

### DIFF
--- a/bigtop-packages/src/common/atlas/patch1-Bump-frontend-maven-plugin-to-support-linux-ppc.diff
+++ b/bigtop-packages/src/common/atlas/patch1-Bump-frontend-maven-plugin-to-support-linux-ppc.diff
@@ -1,0 +1,26 @@
+From 6b05c5921d91e52d9711201f425abc96b5ad4b92 Mon Sep 17 00:00:00 2001
+From: Anton Chevychalov <cab@arenadata.io>
+Date: Tue, 13 Mar 2018 12:04:58 +0300
+Subject: [PATCH] Bump frontend-maven-plugin to support linux/ppc
+
+For additional info see https://github.com/eirslett/frontend-maven-plugin/issues/418
+---
+ pom.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pom.xml b/pom.xml
+index 949167b..4d58a1e 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -1792,7 +1792,7 @@
+                 <plugin>
+                     <groupId>com.github.eirslett</groupId>
+                     <artifactId>frontend-maven-plugin</artifactId>
+-                    <version>1.0</version>
++                    <version>1.6</version>
+                 </plugin>
+ 
+                 <plugin>
+-- 
+2.7.4
+


### PR DESCRIPTION
There is a trouble with frontend-maven-plugin that prevent
to use it on linux/ppc

https://github.com/eirslett/frontend-maven-plugin/issues/418

That was fixed in newer versions of plugin.

That commit bumps version of frontend-maven-plugin for Atlas.