### PR TITLE
ADH-388 Fixup npm for tez on linux/ppc64el

### DIFF
--- a/bigtop-packages/src/common/tez/do-component-build
+++ b/bigtop-packages/src/common/tez/do-component-build
@@ -22,13 +22,11 @@ if [ $HOSTTYPE = "powerpc64le" ] ; then
   git clone https://github.com/ibmsoe/phantomjs-1
   cd phantomjs-1
   export PHANTOMJS_CDNURL=https://github.com/ibmsoe/phantomjs/releases/download/2.1.1
-  npm install -g
+  npm install
+  export PATH=$(pwd)/bin:$PATH
   cd ..
-  rm -rf phantomjs-1
   sed  -i "s|<nodeVersion>.*</nodeVersion>|<nodeVersion>v4.4.7</nodeVersion>|" tez-ui/pom.xml
   sed  -i "s|<npmVersion>.*</npmVersion>|<npmVersion>2.15.3</npmVersion>|" tez-ui/pom.xml
-  sed -i 's|"phantomjs": .*|"phantomjs": "^1.9.19"|' tez-ui/src/main/webapp/package.json
-  sed  -i "s|<frontend-maven-plugin.version>.*</frontend-maven-plugin.version>|<frontend-maven-plugin.version>1.1</frontend-maven-plugin.version>|" pom.xml
 fi
 
 BUILD_TEZ_OPTS="clean package \


### PR DESCRIPTION
There is a special code to install phantomjs on ppc platform. But that code
does not supposed to be run under non root user. That commit change that code
to work under non non root user and remove some dirty version hardcode to
fixup building.