### PR TITLE
CI-83 Allow to override branch and version for gpdb

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -472,9 +472,11 @@ bigtop {
     'gpdb' {
       name    = 'gpdb'
       relNotes = 'GreenPlum'
-      version { base = '5.8.0_arenadata1'; pkg = base; release = 1 }
+      version { base = System.getenv('GPDB_VERSION') ?: '5.8.0_next'
+               pkg = base
+               release = 1 }
       tarball { destination = "${name}-${version.base}.tar.gz"
-                source      = "${version.base}.tar.gz" }
+                source      = System.getenv('GPDB_BRANCH') + ".zip" ?: "${version.base}.zip" }
       url     { site = "https://github.com/arenadata/gpdb/archive/"
                 archive = site }
     }


### PR DESCRIPTION
That commit should be a part of big refactoring of CI.
Currrently there are a lot of troubles to build something
usable from random branch over Bigtop.

How to use that:
`BIGTOP_BUILD_STAMP=$project_id GPDB_VERSION=5.8.0_arendata2 GPDB_BRANCH=adb-5.x /gradle.sh gpdb-rpm`