### PR TITLE
ADBDEV-8 cleanup downloads

### DIFF
--- a/bigtop-packages/src/common/gpdb/do-component-configure
+++ b/bigtop-packages/src/common/gpdb/do-component-configure
@@ -21,6 +21,7 @@ cd add_libs
 xerca_ver=adb-5.x
 wget https://github.com/arenadata/gp-xerces/archive/${xerca_ver}.zip
 unzip ${xerca_ver}.zip
+rm -f ${xerca_ver}.zip
 
 cd gp-xerces-${xerca_ver}
 mkdir build
@@ -33,6 +34,7 @@ cd ../..
 orca_ver=adb-5.x
 wget https://github.com/arenadata/gporca/archive/${orca_ver}.zip
 unzip ${orca_ver}.zip
+rm -f ${orca_ver}.zip
 cd gporca-${orca_ver}
 mkdir build
 cd build


### PR DESCRIPTION
That prevent following error:

+ unzip adb-5.x.zipArchive:  adb-5.x.zip
64bf604fde25de918036bb5fbbdf2ba1e41906c1

replace gp-xerces-adb-5.x/.travis.yml? [y]es, [n]o, [A]ll, [N]one, [r]ename:  NULL
(EOF or read error, treating as "[N]one" ...)
error: Bad exit status from /var/tmp/rpm-tmp.4SUIhM (%install)
    Bad exit status from /var/tmp/rpm-tmp.4SUIhM (%install)