### PR TITLE
ADBDEV-251 Remove useless systemd parameter

### DIFF
--- a/bigtop-packages/src/common/pxf/pxf.service
+++ b/bigtop-packages/src/common/pxf/pxf.service
@@ -9,7 +9,6 @@ User=pxf
 Group=pxf
 ExecStart=/usr/lib/pxf/bin/pxf start
 ExecStop=/usr/lib/pxf/bin/pxf stop
-ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=60
 

--- a/bigtop-packages/src/common/pxf/pxf.service
+++ b/bigtop-packages/src/common/pxf/pxf.service
@@ -12,7 +12,6 @@ ExecStop=/usr/lib/pxf/bin/pxf stop
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=60
-PermissionsStartOnly=true
 
 [Install]
 WantedBy=multi-user.target

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -497,7 +497,7 @@ bigtop {
     'pxf' {
       name    = 'pxf'
       relNotes = 'Framework that allows a distributed database '
-      version { base = '5.6.0'; pkg = base; release = 1 }
+      version { base = '5.6.0'; pkg = base; release = 2 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = "${version.base}.tar.gz" }
       url     { site = "https://github.com/greenplum-db/pxf/archive"


### PR DESCRIPTION
There is a trouble with staring service under root,
while systemV is not woring with root.