### PR TITLE
ADQM-32 Bump version to 19.11.0.0 and hdfs uri patch

### DIFF
--- a/bigtop-packages/src/common/clickhouse/patch0-add-user-parsing-in-hdfs-uri.diff
+++ b/bigtop-packages/src/common/clickhouse/patch0-add-user-parsing-in-hdfs-uri.diff
@@ -1,0 +1,35 @@
+From 74b2440f665159ecb873540130c61a6c3147195b Mon Sep 17 00:00:00 2001
+From: akonyaev <ka@arenadata.io>
+Date: Tue, 9 Jul 2019 13:26:06 +0300
+Subject: [PATCH] add user parsing in HDFS URI
+
+---
+ dbms/src/IO/HDFSCommon.cpp | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/dbms/src/IO/HDFSCommon.cpp b/dbms/src/IO/HDFSCommon.cpp
+index 34cef18068f..e813a367e9f 100644
+--- a/dbms/src/IO/HDFSCommon.cpp
++++ b/dbms/src/IO/HDFSCommon.cpp
+@@ -2,6 +2,7 @@
+ 
+ #if USE_HDFS
+ #include <Common/Exception.h>
++#include <string.h>
+ namespace DB
+ {
+ namespace ErrorCodes
+@@ -25,6 +26,13 @@ HDFSBuilderPtr createHDFSBuilder(const Poco::URI & uri)
+     hdfsBuilderConfSetStr(builder.get(), "input.write.timeout", "60000"); // 1 min
+     hdfsBuilderConfSetStr(builder.get(), "input.connect.timeout", "60000"); // 1 min
+ 
++    std::string userInfo = uri.getUserInfo();
++    if (!userInfo.empty() && userInfo.front() != ':') {
++        char *user = strtok(const_cast<char *> (userInfo.c_str()), ":");
++        if (user != NULL) {
++            hdfsBuilderSetUserName(builder.get(), user);
++        }
++    }
+     hdfsBuilderSetNameNode(builder.get(), host.c_str());
+     hdfsBuilderSetNameNodePort(builder.get(), port);
+     return builder;

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -341,7 +341,7 @@ bigtop {
     'clickhouse' {
       name    = 'clickhouse'
       relNotes = 'ClickHouse'
-      version { base = '19.6.2.11'; pkg = base; release = 1 }
+      version { base = '19.11.0.0'; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = "$name-${version.base}.tgz" }
       git     {repo  = "https://github.com/yandex/ClickHouse.git"


### PR DESCRIPTION
There is a patch from ka@arenadata.io about parsing
hdfs uri which should be applied on top of 19.11.0.0