### PR TITLE
CI-261: It changes apache site name to prevent errors associated with…

### DIFF
--- a/bigtop-packages/src/common/bigtop-tomcat/patch1-change-apache-site.diff
+++ b/bigtop-packages/src/common/bigtop-tomcat/patch1-change-apache-site.diff
@@ -1,0 +1,13 @@
+diff --git a/build.properties.default b/build.properties.default
+index 7873015..e623746 100644
+--- a/build.properties.default
++++ b/build.properties.default
+@@ -56,7 +56,7 @@ compile.source=1.5
+ compile.target=1.5
+ compile.debug=true
+ 
+-base-apache.loc.1=http://www.apache.org/dist
++base-apache.loc.1=http://archive.apache.org/dist
+ base-apache.loc.2=http://archive.apache.org/dist
+ base-commons.loc.1=${base-apache.loc.1}/commons
+ base-commons.loc.2=${base-apache.loc.2}/commons


### PR DESCRIPTION
CI-261: It changes apache site name to prevent errors associated with downloading of tomcat-connector