### PR TITLE
ADBDEV-659 update build.gradle and packages.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,7 +155,7 @@ allprojects {
   targetCompatibility = langLevel
 
   repositories {
-    maven { url "http://repo.maven.apache.org/maven2" }
+    maven { url "https://repo.maven.apache.org/maven2" }
     mavenCentral()
   }
 }

--- a/packages.gradle
+++ b/packages.gradle
@@ -58,7 +58,7 @@ def bomTasks = []
 
 def touchTargetFile = { fileName ->
   // to comply with make build
-  GFileUtils.touch new File(fileName)
+  ant.touch(file:fileName,mkdirs:true)
 }
 def ifExists = { url ->
   if (url == null) return
@@ -120,13 +120,13 @@ Description: Bigtop
 """;
 }
 
-task "packages-help" (description: "All package build related tasks information", group: PACKAGES_GROUP) << {
+task "packages-help" (description: "All package build related tasks information", group: PACKAGES_GROUP) doLast {
   config.bigtop.components.each { label, comp ->
     println (comp.name + "\n\t[" + tasks.findAll { alltask -> alltask.name.startsWith(comp.name)}*.name.join(", ") + "]")
   }
 }
 
-task "bom-json" (description: "List the components of the stack in json format") << {
+task "bom-json" (description: "List the components of the stack in json format") doLast {
   def componentObjects = config.bigtop.components.sort().collect {
     setDefaults(it.value)
     [
@@ -163,7 +163,7 @@ task "bom-json" (description: "List the components of the stack in json format")
   println JsonOutput.prettyPrint(json)
 }
 
-task "all-components" (description: "List the components of the stack") << {
+task "all-components" (description: "List the components of the stack") doLast {
   println "${project.name} ${config.bigtop.version} stack includes the following components"
   config.bigtop.components.sort().each { label, comp ->
     println sprintf ('\t%1$s %2$s', comp.name.padRight(20), comp.version.base.padLeft(15))
@@ -173,7 +173,7 @@ task "all-components" (description: "List the components of the stack") << {
 def genTasks = { target ->
   Task t = task "${target}-download" (dependsOn: "${target}_vardefines",
       description: "Download $target artifacts",
-      group: PACKAGES_GROUP) << {
+      group: PACKAGES_GROUP) doLast {
 
     def final TARBALL_DST = config.bigtop.components[target].tarball.destination
     def final DOWNLOAD_DST = config.bigtop.components[target].downloaddst
@@ -246,7 +246,7 @@ def genTasks = { target ->
   }
   task "${target}-tar" (dependsOn: ["${target}_vardefines", "${target}-download"],
       description: "Preparing a tarball for $target artifacts",
-      group: PACKAGES_GROUP) << {
+      group: PACKAGES_GROUP) doLast {
     if (new File(config.bigtop.components[target].targettar)?.exists()) {
       println "\tNothing to do. Exiting..."
       return
@@ -256,10 +256,11 @@ def genTasks = { target ->
     def final TARBALL_DST = config.bigtop.components[target].tarball.destination
     def final DOWNLOAD_DST = config.bigtop.components[target].downloaddst ?: ""
     def final SEED_TAR = config.bigtop.components[target].seedtar
+    def final DO_NOT_REPACK = config.bigtop.components[target].tarball.donotrepack ?: false
 
     safeDelete(TAR_DIR); mkdir(TAR_DIR)
 
-    if (TARBALL_SRC.isEmpty() || TARBALL_SRC.endsWith('.zip')) {
+    if (TARBALL_SRC.isEmpty() || (TARBALL_SRC.endsWith('.zip') && !DO_NOT_REPACK)) {
       if (TARBALL_SRC.isEmpty()) {
         // if no tar file needed (i.e. bigtop-utils)
         // create some contents to pack later
@@ -303,7 +304,7 @@ def genTasks = { target ->
   // Keeping the reference to deb task to be used later for correct sequencing
   Task tdeb = task "$target-deb"(dependsOn: "${target}-sdeb",
       description: "Building DEB for $target artifacts",
-      group: PACKAGES_GROUP) << {
+      group: PACKAGES_GROUP) doLast {
     if (new File(config.bigtop.components[target].targetdeb)?.exists()) {
       println "\tNothing to do. Exiting..."
       return
@@ -355,7 +356,7 @@ def genTasks = { target ->
    task "$target-sdeb" (dependsOn: ["${target}_vardefines",  "${target}-tar"],
       description: "Building SDEB for $target artifacts",
       group: PACKAGES_GROUP
-  ) << {
+  ) doLast {
     if (new File(config.bigtop.components[target].targetsdeb)?.exists()) {
       println "\tNothing to do. Exiting..."
       return
@@ -431,7 +432,7 @@ def genTasks = { target ->
   // Keeping the reference to task to be used later for correct sequencing
   Task trpm = task "$target-rpm" (dependsOn: ["${target}-srpm"],
       description: "Building RPM for $target artifacts",
-      group: PACKAGES_GROUP) << {
+      group: PACKAGES_GROUP) doLast {
     if (new File(config.bigtop.components[target].targetrpm)?.exists()) {
       println "\tNothing to do. Exiting..."
       return
@@ -476,7 +477,7 @@ def genTasks = { target ->
     trpm.mustRunAfter "${bomTasks.get(bomTasks.size() - 1)}-rpm".toLowerCase()
   task "$target-srpm" (dependsOn: ["${target}_vardefines" , "${target}-tar"],
       description: "Building SRPM for $target artifacts",
-      group: PACKAGES_GROUP) << {
+      group: PACKAGES_GROUP) doLast {
     if (new File(config.bigtop.components[target].targetsrpm)?.exists()) {
       println "\tNothing to do. Exiting..."
       return
@@ -565,17 +566,17 @@ def genTasks = { target ->
     def ptype = nativePackaging.pkg
     task "$target-pkg" (dependsOn: "$target-$ptype",
         description: "Invoking a native binary packaging target $ptype",
-        group: PACKAGES_GROUP) << {
+        group: PACKAGES_GROUP) doLast {
     }
     task "$target-spkg" (dependsOn: "$target-s$ptype",
         description: "Invoking a native binary packaging target s$ptype",
-        group: PACKAGES_GROUP) << {
+        group: PACKAGES_GROUP) doLast {
     }
   }
-  task "$target-version" (description: "Show version of $target component", group: PACKAGES_GROUP) << {
+  task "$target-version" (description: "Show version of $target component", group: PACKAGES_GROUP) doLast {
     println "Base: ${config.bigtop.components[target].version.base}"
   }
-  task "${target}_vardefines" << {
+  task "${target}_vardefines" doLast {
     setDefaults(config.bigtop.components[target])
 
     config.bigtop.components[target].package.release = '1'
@@ -617,7 +618,7 @@ def genTasks = { target ->
 
   task "$target-info" (dependsOn: "${target}_vardefines",
       description: "Info about $target component build",
-      group: PACKAGES_GROUP) << {
+      group: PACKAGES_GROUP) doLast {
     println "Info for package $target"
     println "  Will download from URL: ${config.bigtop.components[target].downloadurl}"
     println "  To destination file: ${config.bigtop.components[target].downloaddst}"
@@ -627,15 +628,15 @@ def genTasks = { target ->
     println "Version: " + config.bigtop.components[target].version.base
     //TODO more about stamping
   }
-  task "$target-relnotes" (description: "Preparing release notes for $target. No yet implemented!!!", group: PACKAGES_GROUP)<< {
+  task "$target-relnotes" (description: "Preparing release notes for $target. No yet implemented!!!", group: PACKAGES_GROUP) doLast {
   }
   task "$target-clean" (dependsOn: "${target}_vardefines",
       description: "Removing $target component build and output directories",
-      group: PACKAGES_GROUP) << {
+      group: PACKAGES_GROUP) doLast {
     safeDelete(config.bigtop.components[target].builddir)
     safeDelete(config.bigtop.components[target].outputdir)
   }
-  task "$target-help" (description: "List of available tasks for $target", group: PACKAGES_GROUP) << {
+  task "$target-help" (description: "List of available tasks for $target", group: PACKAGES_GROUP) doLast {
     println (target + "\n\t[" + tasks.findAll { alltask -> alltask.name.startsWith(target)}*.name.join(", ") + "]")
   }
 
@@ -671,42 +672,42 @@ project.afterEvaluate {
   task "srpm" (dependsOn: tasks.findAll { alltask -> alltask.name.endsWith("-srpm")}*.name,
       description: "Build all SRPM packages for the stack components",
       group: PACKAGES_GROUP
-  ) << { }
+  ) doLast { }
   task "rpm" (dependsOn: tasks.findAll { alltask -> alltask.name.endsWith("-rpm")}*.name,
       description: "Build all RPM packages for the stack",
       group: PACKAGES_GROUP
-  ) << { }
+  ) doLast { }
   task "sdeb" (dependsOn: tasks.findAll { alltask -> alltask.name.endsWith("-sdeb")}*.name,
       description: "Build all SDEB packages for the stack components",
       group: PACKAGES_GROUP
-  ) << { }
+  ) doLast { }
   task "deb" (dependsOn: tasks.findAll { alltask -> alltask.name.endsWith("-deb")}*.name,
       description: "Build all DEB packages for the stack components",
       group: PACKAGES_GROUP
-  ) << { }
+  ) doLast { }
   task "pkgs" (dependsOn: tasks.findAll { alltask -> alltask.name.endsWith("-pkg")}*.name,
       description: "Build all native packages for the stack components",
       group: PACKAGES_GROUP
-  ) << { }
+  ) doLast { }
 
   task allclean (dependsOn: [clean, tasks.findAll { alltask -> alltask.name.endsWith("-clean")}*.name],
       description: "Removing $BUILD_DIR, $OUTPUT_DIR, and $DIST_DIR.\n\t\t" +
         "Cleaning all components' build and output directories.",
-      group: PACKAGES_GROUP) << {
+      group: PACKAGES_GROUP) doLast {
     safeDelete(BUILD_DIR)
     safeDelete(OUTPUT_DIR)
     safeDelete(DIST_DIR)
   }
   task realclean (dependsOn: allclean,
       description: "Removing $BUILD_DIR, $OUTPUT_DIR, $DIST_DIR, and $DL_DIR",
-      group: PACKAGES_GROUP) << {
+      group: PACKAGES_GROUP) doLast {
     delete (DL_DIR)
   }
 }
 
 task "apt" (
     description: "Creating APT repository",
-    group: PACKAGES_GROUP) << {
+    group: PACKAGES_GROUP) doLast {
 
   delete ( "$OUTPUT_DIR/apt")
   mkdir ("$OUTPUT_DIR/apt/conf")
@@ -725,7 +726,7 @@ task "apt" (
 
 task "yum" (
     description: "Creating YUM repository",
-    group: PACKAGES_GROUP) << {
+    group: PACKAGES_GROUP) doLast {
   delete ( "$OUTPUT_DIR/repodata")
   exec {
     workingDir BUILD_DIR
@@ -736,5 +737,5 @@ task "yum" (
 if (nativePackaging) {
   task "repo" (dependsOn: nativePackaging.repo,
       description: "Invoking a native repository target ${nativePackaging.repo}",
-      group: PACKAGES_GROUP) << { }
+      group: PACKAGES_GROUP) doLast { }
 }


### PR DESCRIPTION
Adb 6 use old version of bigtop scrips. This patch updates this scripts to the versions used in other products (adh, adqm, ads) and  corrects errors